### PR TITLE
Fixes for regular expressions used for header parsing

### DIFF
--- a/parse-header.js
+++ b/parse-header.js
@@ -31,7 +31,7 @@ module.exports = function parseHeader (data) {
   }
 
   // INTERFACE
-  const interfaceRegex = /@interface ([^ ]+)( : ([^ \n]+)( <([^>\n]+)>){0,1}){0,1}/g;
+  const interfaceRegex = /@interface ([^ \n]+)( : ([^ \n]+)( <([^>\n]+)>){0,1}){0,1}/g;
   let matchInterface;
   while ((matchInterface = interfaceRegex.exec(data)) !== null) {
     if (matchInterface.index === interfaceRegex.lastIndex) {
@@ -45,7 +45,7 @@ module.exports = function parseHeader (data) {
   }
 
   // PROTOCOL
-  const protocolRegex = /@protocol ([^ ]+)( : ([^ \n]+)( <([^>\n]+)>){0,1}){0,1}/g;
+  const protocolRegex = /@protocol ([^ \n]+)( : ([^ \n]+)( <([^>\n]+)>){0,1}){0,1}/g;
   let matchProtocol;
   while ((matchProtocol = protocolRegex.exec(data)) !== null) {
     if (matchProtocol.index === matchProtocol.lastIndex) {

--- a/parse-header.js
+++ b/parse-header.js
@@ -68,7 +68,7 @@ module.exports = function parseHeader (data) {
     }
     let name = '';
     let args = [];
-    const methodNameRegex = /([^:]+)(:\(([^\)]+)\)([^ ]+))*/g;
+    const methodNameRegex = /([^:]+)(:\((([^\(\)]*\(\^\)\s*\()*[^\)]+\)*)\)([^ ]+))*/g;
     let matchMethodName;
     while ((matchMethodName = methodNameRegex.exec(matchMethod[3])) !== null) {
       name += `${matchMethodName[1].trim()}${matchMethodName[2] ? ':' : ''}`;


### PR DESCRIPTION
This PR fixes issues with regular expressions that are used to extract data from header files.

* Improved name-extracting regexes, so these will now handle correctly the case when name is immediately followed by line-break symbol.
* Fixed regex for extracting method arguments.

Details:

```
@protocol AFMultipartFormData
- (void)throttleBandwidthWithPacketSize:(unsigned long long)arg1 delay:(double)arg2;
@end
```

```
@class NSArray;

@protocol MSDocumentData
@property(readonly, nonatomic) NSArray *pages;
@end
```

Previously match was spanning on 2 lines, resulting in weird names like `AFMultipartFormData\n-` or `MSDocumentData\n@property(readonly,`.
