### PR TITLE
Include name property in method `args` definition

### DIFF
--- a/parse-header.js
+++ b/parse-header.js
@@ -64,6 +64,7 @@ module.exports = function parseHeader (data) {
       name += `${matchMethodName[1].trim()}${matchMethodName[2] ? ':' : ''}`;
       if (matchMethodName[3]) {
         args.push({
+          name: matchMethodName[1].trim(),
           type: matchMethodName[3]
         });
       }


### PR DESCRIPTION
Added `name` property for items in method's `args` array. Resolves #10 .